### PR TITLE
レスポンス時にAccess-Control-Allow-Origin ヘッダをつけるように設定

### DIFF
--- a/a6s-cloud/app/Http/Kernel.php
+++ b/a6s-cloud/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\Cors::class,
     ];
 
     /**

--- a/a6s-cloud/app/Http/Middleware/Cors.php
+++ b/a6s-cloud/app/Http/Middleware/Cors.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class Cors
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        return $next($request)
+            ->header('Access-Control-Allow-Origin', '*')
+            ->header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    }
+}


### PR DESCRIPTION
いくつか方式はありそうでしたが、middleware
を使って解決する方法にしてみました。
Access-Control-Allow-Origin: の値を"*"
としていますが、仮の値です。今後検証環境や本番環境のFQDN
が固まってきた時に厳密に決めるべきと思います。
参考にしたサイトは以下:
https://stackoverflow.com/questions/39429462/adding-access-control-allow-origin-header-response-in-laravel-5-3-passport
https://www.youtube.com/watch?v=1U74kJKy9XU

一応、レスポンスにAccess-Control-Allow-Origin ヘッダが追加されていることは確認しましたので、お時間あるときになおとさんのお手元でご確認いただければと思います！
![p](https://user-images.githubusercontent.com/10674169/53340596-bd6f5a80-394c-11e9-90be-52a11059be1c.png)
