### PR TITLE
タイムゾーンをAsia/Tokyo に設定 #26

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,7 @@ main() {
 }
 
 build() {
+    rm -rf laradock
     git submodule update --init --recursive
 
     cd laradock
@@ -61,6 +62,7 @@ build() {
     echo 'DB_HOST=mysql'            >> .env
     echo '# REDIS_HOST=redis'       >> .env
     echo 'QUEUE_HOST=beanstalkd'    >> .env
+    sed -i "s|^WORKSPACE_TIMEZONE=.*|WORKSPACE_TIMEZONE=Asia/Tokyo|g"  .env
 
     docker-compose up -d nginx mysql workspace
 


### PR DESCRIPTION
現状workspace(PHP/Laravel), mysql
環境のコンテナはタイムゾーンの設定が反映されますが、laradock のdocker-compose
を見た所、nginxコンテナのタイムゾーンは設定しないようになっているみたいです(UTC のまま)。
nginxについてはタイムゾーンを設定しないようになっている理由などを時間ある時に調査してみようと思いますが、本件は我々側の問題ではないのでプルリクエストさせてもらいました。