### PR TITLE
Mac 環境とLinux 環境とでコマンドのオプションを変更するように修正 #30

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,13 @@ main() {
     return 0
 }
 
+function is_mac() {
+    if [ "$(uname)" == "Darwin" ] || (command -v brew > /dev/null 2>&1); then
+        return 0
+    fi
+    return 1
+}
+
 build() {
     rm -rf laradock
     git submodule update --init --recursive
@@ -62,7 +69,12 @@ build() {
     echo 'DB_HOST=mysql'            >> .env
     echo '# REDIS_HOST=redis'       >> .env
     echo 'QUEUE_HOST=beanstalkd'    >> .env
-    sed -i "" "s|^WORKSPACE_TIMEZONE=.*|WORKSPACE_TIMEZONE=Asia/Tokyo|g"  .env
+
+    if is_mac; then
+        sed -i "" -e "s|^WORKSPACE_TIMEZONE=.*|WORKSPACE_TIMEZONE=Asia/Tokyo|g"  .env
+    else
+        sed -i -e "s|^WORKSPACE_TIMEZONE=.*|WORKSPACE_TIMEZONE=Asia/Tokyo|g"  .env
+    fi
 
     docker-compose up -d nginx mysql workspace
 


### PR DESCRIPTION
build.sh 内のsed コマンドのオプションを本日対面時にMac で動くように直してもらったのですが、そしたら今度はLinux 側で動かなくなってしまいました(Linux 側でも動くから大丈夫といっていたのは自分ですが…)。
なので、Mac とLinux でsed コマンドのオプションを変えるようにしました。
お手数ですがご確認よろしくおねがいします。