### PR TITLE
laradock のsubmodule 内のファイル変更時にstatus に表示されないように修正 Close #28

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "laradock"]
 	path = laradock
 	url = https://github.com/Laradock/laradock.git
+	ignore = dirty


### PR DESCRIPTION


以下コマンドを実行してlaradock
ディレクトリ以下のファイルに変更があった時にstatus
表示されないようにしました。
git config --file .gitmodules submodule.laradock.ignore dirty

...当初.gitignore
に追加すれば良いと思っていましたが、それでは消えませんでした(想定外)。
https://rcmdnk.com/blog/2013/10/18/computer-git/#ignore--dirty