### PR TITLE
build.sh でMySQL データが初期化されていなかった部分を修正

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -134,7 +134,8 @@ init_mysql_db() {
             echo "ERROR: File /tmp/drop_all_tables.sql is not found." >&2
             exit 1
         fi
-        if [[ "$(wc -c < foo.txt)" -ne 0 ]]; then
+        if [[ "$(wc -c < /tmp/drop_all_tables.sql)" -ne 0 ]]; then
+            echo "MYSQL_PWD=****** mysql -u root a6s_cloud < /tmp/drop_all_tables.sql"
             MYSQL_PWD=${DB_PW_ROOT} mysql -u root a6s_cloud                                                     <  /tmp/drop_all_tables.sql
         fi
         rm -f /tmp/drop_all_tables.sql


### PR DESCRIPTION
# 対応内容
MySQL データを初期化する条件分岐が誤っていた(ボンミス)ためその条件分岐を修正

# 確認方法
\#技術書典6 でPOST リクエストを飛ばして成功(tweets テーブルに何かしらの絵文字を登録)した後、build.sh を実行。エラーがなければOK

# クローズするissue
close #62

# このタスクで発生したissue
なし

# その他
特になし