### PR TITLE
urlとretweet_countのデータを登録

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -24,7 +24,7 @@ class AnalysisRequestsController extends Controller
         $aResult->analysis_start_date = $start_date;
         $aResult->analysis_end_date = $start_date;
         $aResult->analysis_word = $analysis_word;
-        // $aResult->url = $url; TODO:カラムを追加する必要あり
+        $aResult->url = $url;
         $aResult->status = 1;
         $aResult->save();
 
@@ -115,6 +115,7 @@ class AnalysisRequestsController extends Controller
         $aResult->favorite_count = $total_favorite;
         $aResult->tweet_count = $total_tweet;
         $aResult->favorite_count = $total_favorite;
+        $aResult->retweet_count = $total_retweet;
         $aResult->save();
 
         // IDを取得を返す


### PR DESCRIPTION
# 対応内容
#47 と #52  の内容を修正しました。

# 確認方法
#64 を先にマージして、analysis_resultsテーブルにurlとretweet_countの追加をお願いします。
`http://localhost/api/v1/AnalysisRequests`にリクエストを投げて、urlとretweet_countにデータが入ることの確認をお願いします。

# クローズするissue
close #47
close #52

# このタスクで発生したissue
なし

# その他
なし