### PR TITLE
Python モジュールをインストールするコンテナをphp-fpm に変更

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = RictyDiminished
 	url = https://github.com/edihbrandon/RictyDiminished.git
 	ignore = dirty
+[submodule "a6s-cloud-batch"]
+	path = a6s-cloud-batch
+	url = git@github.com:nsuzuki7713/a6s-cloud-batch.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,9 +2,6 @@
 	path = laradock
 	url = https://github.com/Laradock/laradock.git
 	ignore = dirty
-[submodule "a6s-cloud-batch"]
-	path = a6s-cloud-batch
-	url = https://github.com/nsuzuki7713/a6s-cloud-batch.git
 [submodule "RictyDiminished"]
 	path = RictyDiminished
 	url = https://github.com/edihbrandon/RictyDiminished.git

--- a/build.sh
+++ b/build.sh
@@ -145,7 +145,7 @@ init_mysql_db() {
         MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "ALTER USER '"'"'default'"'"'@'"'"'%'"'"' IDENTIFIED WITH mysql_native_password BY '"'"'secret'"'"';"
         # MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "SELECT user, host, plugin FROM mysql.user;" | grep -E "^default"
     '
-    docker-compose exec workspace bash -c '
+    docker-compose exec php-fpm bash -c '
         set -e
 
         pkg_cache=$(apt list --installed 2> /dev/null | grep -v -E "Listing..." | cut -d "/" -f 1)


### PR DESCRIPTION
# 対応内容
Python モジュールをworkspace コンテナにインストールしていたが、php-fpm に変更。
Laravel がバッチを叩く時はphp-fpm コンテナから叩いているため。

# 確認方法
※前回と同様の手順
(1)手元にpull したあとコンテナを一旦削除する
```
$ pushd laradock
$ docker-compose rm -f
$ popd
```
(2)build.sh を実行してコンテナを再構築する
```
$ ./build.sh
```

(3)以下のコマンドを実行してコンテナ上でWord Cloud を実行する
※`docker exec ...` は2 行で1 コマンドです。
```
$ docker exec laradock_php-fpm_1 su - www-data -s /bin/bash -c \
    'python3 a6s-cloud-batch/src/createWordCloud.py a6s-cloud-batch/test_data/tweet1.txt RictyDiminished/RictyDiminished-Bold.ttf /var/www/result.png'

$ ls -l result.png
// 対象はlaradock_php-fpm_1 コンテナです。result.png ができているはず
```

# クローズするissue
Close #81

# このタスクで発生したissue
なし

# その他
なし