### PR TITLE
Laravel からWord Cloud API を実行する処理を追加

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -145,7 +145,7 @@ init_mysql_db() {
         MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "ALTER USER '"'"'default'"'"'@'"'"'%'"'"' IDENTIFIED WITH mysql_native_password BY '"'"'secret'"'"';"
         # MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "SELECT user, host, plugin FROM mysql.user;" | grep -E "^default"
     '
-    docker-compose exec workspace bash -c '
+    docker-compose exec php-fpm bash -c '
         set -e
 
         pkg_cache=$(apt list --installed 2> /dev/null | grep -v -E "Listing..." | cut -d "/" -f 1)


### PR DESCRIPTION
# 対応内容
Laravel からWord Cloud API を実行する処理を追加。

# 確認方法
例えば`analysis_word=#技術書典`、`start_date=2019-04-14` でリクエストを飛ばすとそのTweet を取得してきてWord Cloud 画像を生成します。
画像は仮でリポジトリのroot にresult.png というファイルで保存されます。

# クローズするissue
Close #82  <- こちらを先にマージしてもらえると嬉しいです
Close #12

# このタスクで発生したissue
Word Cloud 画像の出力先にlocal storage を使う #84
出力したWord Cloud 画像をDB に保存する処理を追加する #85
Word Cloud 画像生成処理に失敗した時のエラー処理を追加する #86

# その他
上記issue 番号は実際にissue 建ててから編集します