### PR TITLE
WordCloud の結果保存先にlocal storage を使うよう修正

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -40,7 +40,9 @@ class AnalysisRequestsController extends Controller
         // wordcloud 解析用のファイルpath を作成する
         // TODO: uuid をつかって一意なファイル名を作成するようにしているが、念の為そのファイルが既に作成されていないかチェックすべき
         // TODO: a6s-cloud-batch 処理成功後にこのファイルを削除する処理を追加すべき
-        $tweetsFileForWordcloud = (string) str::uuid() . ".txt";
+        $uuid = (string) str::uuid();
+        $tweetsFileForWordcloud = $uuid . ".txt";
+        $imageFileForWordcloud = $uuid . ".png";
         $localStorage = Storage::disk('local');
         $localStoragePath = $localStorage->getDriver()->getAdapter()->getPathPrefix();
         // logger(print_r('次のファイルにwordcloud用tweet データを保存します[' . $localStoragePath . $tweetsFileForWordcloud . ']', true));
@@ -131,7 +133,7 @@ class AnalysisRequestsController extends Controller
             '../../a6s-cloud-batch/src/createWordCloud.py',
             $localStoragePath . $tweetsFileForWordcloud,
             '../../RictyDiminished/RictyDiminished-Bold.ttf',
-            '/var/www/result.png'    // TODO: 出力先にはlocal storage を使うべきか
+            $localStoragePath . $imageFileForWordcloud
         ]);
         // TODO: 出力したファイルをDB に保存する処理を追加する
         $process->run();


### PR DESCRIPTION
# 対応内容
#84 の対応をしました。
Word Cloud の結果画像出力先をlocal storage を使うようにしました。

# 確認方法
適当なハッシュタグ指定でPOST リクエストを飛ばしてください。
例) 2019/04/17 の夜現在トレンドに入っていたハッシュタグでリクエストを飛ばす
```
echo -en 'start_date=2019-04-17&analysis_word=#令和に恋人できるかな&url=https://github.com/nsuzuki7713/a6s-cloud-front/&analysis_timing=[1,3]' \
        | curl http://localhost/api/v1/AnalysisRequests --data-binary @- > ~/result.html
```

リクエスト送信後`a6s-cloud/storage/app/` ディレクトリにWord Cloud 画像が出力されていれば成功です。

```
$ ls -l a6s-cloud/storage/app/*.png
```

# クローズするissue
close #84

# このタスクで発生したissue
#88

# その他
local storage を使うつもりが、ただ単にlocal storage のフルPATH を組み立ててWord Cloud バッチに渡すような感じになってしまいました。
より綺麗な方法があったら教えてください。