### PR TITLE
Word Cloud 画像生成失敗時にHTTP 500 レスポンスを返すように修正

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -138,8 +138,14 @@ class AnalysisRequestsController extends Controller
         // TODO: 出力したファイルをDB に保存する処理を追加する
         $process->run();
         if (!$process->isSuccessful()) {
-            // TODO: HTTP ステータス500 とか返したほうが良い?
-            throw new ProcessFailedException($process);
+            $aResult->status = 3;
+            $aResult->save();
+
+            $e = new ProcessFailedException($process);
+            logger(print_r($e->getMessage(), true));
+            logger(print_r($e->getTraceAsString(), true));
+
+            return response($aResult->id, 500);
         }
 
         // update処理


### PR DESCRIPTION
# 対応内容
Word Cloud 画像生成失敗時にHTTP 500 レスポンスを返すように修正。
それに加えて、ANALSIS_RESULTS のstatus を3 に変更し、Stack Trace をログに出力するようにもした。

# 確認方法
* Process でコマンド実行している所で、エラーがでるようにする(例: python3 -> python4 と書き換える)
* 適当なリクエストを飛ばす
例:
```
echo -en 'start_date=2019-04-20&analysis_word=#終身雇用&url=https://github.com/nsuzuki7713/a6s-cloud-front/&analysis_timing=[1,3]' | curl http://localhost/api/v1/AnalysisRequests --data-binary @-
```
* HTTP 500 のレスポンスが返ってくること
* ANALSIS_RESULTS のstatus が3 になっていること
* a6s-cloud/storage/logs 下のファイルにStack Trace が表示されること
```
[2019-04-20 03:40:33] local.DEBUG: The command "'python4' '../../a6s-cloud-batch/src/createWordCloud.py' '/var/www/a6s-cloud/storage/app/920be163-9c38-4c2c-8a53-ef3f4ed30dda.txt' '../../RictyDiminished/RictyDiminished-Bold.ttf' '/var/www/a6s-cloud/storage/app/920be163-9c38-4c2c-8a53-ef3f4ed30dda.png'" failed.
... 略
sh: 1: exec: python4: not found

[2019-04-20 03:40:33] local.DEBUG: #0 [internal function]: App\Http\Controllers\AnalysisRequestsController->create(Object(Illuminate\Support\Facades\Request))
#1 /var/www/a6s-cloud/vendor/laravel/framework/src/Illuminate/Routing/Controller.php(54): call_user_func_array(Array, Array)
#2 /var/www/a6s-cloud/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(45): Illuminate\Routing\Controller->callAction('create', Array)
... 略
```

# クローズするissue
close #86

# このタスクで発生したissue
#93

# その他
特になし