### PR TITLE
Add parameter validation#46

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -7,11 +7,11 @@ use \DateTimeZone;
 
 use App\AnalysisResults;
 use App\Tweets;
-use Request;
 use Illuminate\Http\Request as HttpRequest;
-use Abraham\TwitterOAuth\TwitterOAuth;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Abraham\TwitterOAuth\TwitterOAuth;
 use Carbon\Carbon;
 
 use Symfony\Component\Process\Process;

--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -8,6 +8,7 @@ use \DateTimeZone;
 use App\AnalysisResults;
 use App\Tweets;
 use Request;
+use Illuminate\Http\Request as HttpRequest;
 use Abraham\TwitterOAuth\TwitterOAuth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -18,8 +19,14 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class AnalysisRequestsController extends Controller
 {
-    public function create(Request $request)
+    public function create(Request $request, HttpRequest $httpRequest)
     {
+        $httpRequest->validate([
+            'start_date' => 'required',
+            'analysis_word' => 'required',
+            'analysis_timing' => 'required'
+        ]);
+
         // パラメータを取得
         $start_date = $request::input('start_date');
         $analysis_word = $request::input('analysis_word');


### PR DESCRIPTION
必須チェックのバリデーションを実装。

# 対応内容
Twitter APIへの下記リクエストパラメータ３種に必須チェックを追加。
* start_date
* analysis_word
* analysis_timing

# 確認方法
エンドポイント ```api/v1/AnalysisRequests``` にPOSTでリクエストしてください。
* 正常値
リクエスト例

| key | value |
| ---------- | ---- |
| start_date | 2019/04/25 |
| analysis_word | #test |
| analysis_timing | [1,3] |

* 返却値
ID

* 異常
  * いずれかのkeyが存在しないこと
  * いずれかの値がNULLであること

* 返却値
  * リクエスト直前の画面にリダイレクトされる

# クローズするissue
close #46

# このタスクで発生したissue
#99 Requestのファサードを用いてinputを静的呼び出ししているが、バリデーションの拡張性などを考えてDIによるオブジェクト読み込みに統一したい。

# その他
直前の画面にリダイレクトされるが、SPAの場合にこれで上手くいくのか…？
参考になりそうな記事: https://qiita.com/zaburo/items/b80d4ae73efc99b41541