### PR TITLE
requestファサードをrequestDIに変更 #99

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -7,8 +7,7 @@ use \DateTimeZone;
 
 use App\AnalysisResults;
 use App\Tweets;
-use Illuminate\Http\Request as HttpRequest;
-use Illuminate\Support\Facades\Request;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Abraham\TwitterOAuth\TwitterOAuth;
@@ -19,19 +18,19 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class AnalysisRequestsController extends Controller
 {
-    public function create(Request $request, HttpRequest $httpRequest)
+    public function create(Request $request)
     {
-        $httpRequest->validate([
+        $request->validate([
             'start_date' => 'required',
             'analysis_word' => 'required',
             'analysis_timing' => 'required'
         ]);
 
         // パラメータを取得
-        $start_date = $request::input('start_date');
-        $analysis_word = $request::input('analysis_word');
-        $url = $request::input('url');
-        $analysis_timing = $request::input('analysis_timing');
+        $start_date = $request->input('start_date');
+        $analysis_word = $request->input('analysis_word');
+        $url = $request->input('url');
+        $analysis_timing = $request->input('analysis_timing');
 
         // 抽出日付形式をハイフンに変換
         $carbon = new Carbon($start_date);


### PR DESCRIPTION
requestファサードの利用を廃止し、requestDIに統一。

# 対応内容
Illuminate\Support\Facades\Request から Illuminate\Http\Request に統一しました。

# 確認方法
見た目上の挙動は変化なしなので、リグレがないか確認してください。

# クローズするissue
close #99 

~~# このタスクで発生したissue~~

# その他
ブランチ名が死ぬほどダサくてテンションが下がったので、誰かいいブランチ名あるよって人はこっそり教えてください。