### PR TITLE
word cloudで投稿した際にtweetできるように機能追加

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -166,6 +166,16 @@ class AnalysisRequestsController extends Controller
         $aResult->retweet_count = $total_retweet;
         $aResult->save();
 
+        // word cloudの画像を添付してツイートをする
+        // ※動作確認する場合はコメントアウトを外してくだい
+        // TODO:投稿文言は要検討
+        // $media1 = $this->twitter_client->upload('media/upload', ['media' => $localStoragePath . $imageFileForWordcloud]);
+        // $parameters = [
+        //     'status' => "実装テストちゅうです！！\nテスト",
+        //     'media_ids' => implode(',', [$media1->media_id_string]),
+        // ];
+        // $result = $this->twitter_client->post('statuses/update', $parameters);
+
         // IDを取得を返す
         return response($aResult->id, 200);
     }


### PR DESCRIPTION
# 対応内容
#106  の内容を対応となります。

# 確認方法
実装中の動作確認でtweetするのも煩わしい気がしたのでコメントアウトでプルリク出しています。
動作確認する際はコメントを外して確認お願いします。
word cloudの画像と共にTweetされます。
※文言とかは適宜変えてもらっても大丈夫です

<img width="634" alt="スクリーンショット 2019-04-27 0 56 31" src="https://user-images.githubusercontent.com/34429882/56821031-50167200-6888-11e9-9e14-2056988a1cfb.png">

# クローズするissue
close #106

# このタスクで発生したissue
特になし

# その他
特になし

# 参考URL
https://twitteroauth.com/