### PR TITLE
解析結果画像の保存先をpublic 化

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -54,7 +54,8 @@ class AnalysisRequestsController extends Controller
         $imageFileForWordcloud = $uuid . ".png";
         $localStorage = Storage::disk('local');
         $localStoragePath = $localStorage->getDriver()->getAdapter()->getPathPrefix();
-        // logger(print_r('次のファイルにwordcloud用tweet データを保存します[' . $localStoragePath . $tweetsFileForWordcloud . ']', true));
+        $publicStoragePath = Storage::disk('public')->getDriver()->getAdapter()->getPathPrefix();
+        // logger(print_r('ファイル保存先: ' . $publicStoragePath . $imageFileForWordcloud . ', URL -> ' . asset('storage/' . $imageFileForWordcloud), true));
 
         // twitterデータ取得
         $twitter_config = config('twitter');
@@ -143,7 +144,7 @@ class AnalysisRequestsController extends Controller
             '../../a6s-cloud-batch/src/createWordCloud.py',
             $localStoragePath . $tweetsFileForWordcloud,
             '../../RictyDiminished/RictyDiminished-Bold.ttf',
-            $localStoragePath . $imageFileForWordcloud
+            $publicStoragePath . $imageFileForWordcloud
         ]);
         // TODO: 出力したファイルをDB に保存する処理を追加する
         $process->run();
@@ -164,6 +165,7 @@ class AnalysisRequestsController extends Controller
         $aResult->tweet_count = $total_tweet;
         $aResult->favorite_count = $total_favorite;
         $aResult->retweet_count = $total_retweet;
+        $aResult->image = $imageFileForWordcloud;
         $aResult->save();
 
         // word cloudの画像を添付してツイートをする

--- a/build.sh
+++ b/build.sh
@@ -204,6 +204,7 @@ init_mysql_db() {
 
     docker-compose exec workspace runuser -l laradock -c '
         cd /var/www/a6s-cloud
+        [[ ! -L ./public/storage ]] && php artisan storage:link
         php artisan migrate:refresh
         php artisan db:seed
     '


### PR DESCRIPTION
# 対応内容
#98 の対応をしました

# 確認方法
* build.sh を実行して正常にコンテナが立ち上がること
* analysis_results テーブルのimage フィールドに解析結果ファイル名が保存されていること。
* http://localhost/storage/<作成された画像ファイル名>.png にアクセスして作成されたファイルが参照できること

# クローズするissue
close #98

# このタスクで発生したissue
なし

# その他
`php artisan storage:link` すると`/a6s-cloud/public/storage` にシンボリックリンクが作成されますが、Laravel プロジェクトの.gitignore にstorage シンボリックリンクが追加されているためコミットできない(OS 環境差異を考慮しての追加？)。
なのでbuild 時にphp artisan コマンドを発行する方針で対応しました(build.sh に追加)。