### PR TITLE
RTの場合いいねとRTのサマリ計算をしない

### DIFF
--- a/a6s-cloud/app/Services/TwitterClientService.php
+++ b/a6s-cloud/app/Services/TwitterClientService.php
@@ -63,8 +63,11 @@ class TwitterClientService
                 $summary["total_users_map"][$value->user->screen_name] = null;
 
                 // サマリを計算
-                $summary["total_retweet"] = $summary["total_retweet"] + $value->retweet_count;
-                $summary["total_favorite"] = $summary["total_favorite"] + $value->favorite_count;
+                if(substr($value->text, 0, 2) !== "RT"){
+                    // RT以外のみ「いいね」、「リツート」を加算する
+                    $summary["total_retweet"] = $summary["total_retweet"] + $value->retweet_count;
+                    $summary["total_favorite"] = $summary["total_favorite"] + $value->favorite_count;
+                }
                 $summary["total_tweet"] = $summary["total_tweet"] + 1;
 
                 // wordcloud用のテキストファイルにtweet データを保存


### PR DESCRIPTION
# 対応内容
#113 の内容を対応しました。

# 確認方法
analysis_resultsテーブルのfavorite_countとretweet_countが膨大ではないことを確認お願いします。
※詳細の件数まではテストしていないので、雰囲気で大丈夫です。

一応retweet_countは下記SQLを実行して、phpの結果と一致したかを確認しました。
```
select sum(retweet_count) from tweets where analysis_result_id = 2 
select sum(retweet_count) from tweets where analysis_result_id = 2 and SUBSTRING(text,1,2) != "RT"
select sum(retweet_count) from tweets where analysis_result_id = 2 and SUBSTRING(text,1,2) = "RT"
```

# クローズするissue
close #113 

# このタスクで発生したissue
特になし

# その他
正規表現の条件比較も可能でした、substrのほうが早いという記事を見つけたのでsubstrを使用しました！！
https://symfoware.blog.fc2.com/blog-entry-1812.html