### PR TITLE
Fix module ref to https#120

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = RictyDiminished
 	url = https://github.com/edihbrandon/RictyDiminished.git
 	ignore = dirty
+[submodule "a6s-cloud-batch"]
+	path = a6s-cloud-batch
+	url = https://github.com/nsuzuki7713/a6s-cloud-batch.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,3 @@
 	path = RictyDiminished
 	url = https://github.com/edihbrandon/RictyDiminished.git
 	ignore = dirty
-[submodule "a6s-cloud-batch"]
-	path = a6s-cloud-batch
-	url = git@github.com:nsuzuki7713/a6s-cloud-batch.git


### PR DESCRIPTION
# 対応内容
#120 の内容を修正しました。

# 確認方法
どこかに新規にリポジトリをclone して`fix_module_ref_to_https#120` ブランチをチェックアウトしてsubmodule コマンドを実行して問題なく成功すること。認証要求されないこと。

```
$ grep a6s-cloud-batch .gitmodules
[submodule "a6s-cloud-batch"]
        path = a6s-cloud-batch
        url = https://github.com/nsuzuki7713/a6s-cloud-batch.git

$ git submodule update --init --recursive
```

# クローズするissue
close #120

# このタスクで発生したissue
なし

# その他
なし