### PR TITLE
フロント側からのキャメルケースリクエストをスネークケースに変更する処理を追加

### DIFF
--- a/a6s-cloud/app/Http/Middleware/Cors.php
+++ b/a6s-cloud/app/Http/Middleware/Cors.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Http\Middleware;
 use Closure;
+use Illuminate\Support\Str;
+
 class Cors
 {
     /**
@@ -12,6 +14,13 @@ class Cors
      */
     public function handle($request, Closure $next)
     {
+        $requestParameters = $request->all();
+        $snakeParameters = array();
+        foreach($requestParameters as $key => $value) {
+            $snakeParameters[Str::snake($key)] = $value;
+        }
+        $request->replace($snakeParameters);
+
         return $next($request)
             ->header('Access-Control-Allow-Origin', '*')
             ->header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');


### PR DESCRIPTION
# 対応内容
#134 の内容を修正しました。
コントローラに処理が渡る前に、リクエストパラメータのkey を一律スネークケースに変更。

# 確認方法
キャメルケースのリクエストパラメータを投げて、正常に処理が終了することを確認
例)
```
echo -en 'startDate=2019-05-04&analysisWord=#打ち上げ成功&url=https://github.com/nsuzuki7713/a6s-cloud-front/&analysisTiming=[1,3]' | curl http://localhost/api/v1/AnalysisRequests --data-binary @- 
```

# クローズするissue
close #134

# このタスクで発生したissue
https://github.com/nsuzuki7713/a6s-cloud-front/issues/91

# その他
このタスクで発生したissue は画面側から実際に解析依頼出した時にvalidation で引っかかったため気づきました…。