### PR TITLE
NGワードで解析依頼できないよに修正

### DIFF
--- a/a6s-cloud/app/BlackAnalysisWords.php
+++ b/a6s-cloud/app/BlackAnalysisWords.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class  BlackAnalysisWords extends Model
+{
+    public $timestamps = false;
+}

--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -7,6 +7,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 use AnalysisRequestService;
 use TwitterClientService;
 use App\Rules\NonDuplicateAnalysisRequest;
+use App\Rules\NGAnalysisWord;
 
 class AnalysisRequestsController extends Controller
 {
@@ -15,7 +16,7 @@ class AnalysisRequestsController extends Controller
         // バリデーション処理
         $request->validate([
             'start_date' => 'required',
-            'analysis_word' => ['required', new NonDuplicateAnalysisRequest($request)],
+            'analysis_word' => ['required', new NonDuplicateAnalysisRequest($request), new NGAnalysisWord],
             'analysis_timing' => 'required'
         ]);
 

--- a/a6s-cloud/app/Rules/NGAnalysisWord.php
+++ b/a6s-cloud/app/Rules/NGAnalysisWord.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class NGAnalysisWord implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return true
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'Error has occured due to ng analysis word was passed';
+    }
+}

--- a/a6s-cloud/app/Rules/NGAnalysisWord.php
+++ b/a6s-cloud/app/Rules/NGAnalysisWord.php
@@ -3,6 +3,7 @@
 namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use App\BlackAnalysisWords;
 
 class NGAnalysisWord implements Rule
 {
@@ -25,7 +26,7 @@ class NGAnalysisWord implements Rule
      */
     public function passes($attribute, $value)
     {
-        return true
+        return !BlackAnalysisWords::where('analysis_ng_word', '=', $value)->exists();
     }
 
     /**


### PR DESCRIPTION
# 対応内容
#142 の内容を修正しました。

# 確認方法
まず、テーブルにNGワードを追加してください
例) #editor_war を追加する場合
```
INSERT INTO black_analysis_words (analysis_ng_word, availability_flag) VALUES ('#editor_war', 0);
```

登録したワードで解析依頼を出してください。
例)curl の場合
```
echo -en 'start_date=2019-05-07&analysis_word=#editor_war&url=https://github.com/nsuzuki7713/a6s-cloud-front/&analysis_timing=[1,3]' \
        | curl http://localhost/api/v1/AnalysisRequests --data-binary @-
```

# クローズするissue
close #142

# このタスクで発生したissue
なし

# その他
重複した解析ワードと日付と同様なロジックで実装しておきました。