### PR TITLE
解析依頼バッチ処理の追加

### DIFF
--- a/a6s-cloud/app/Console/Kernel.php
+++ b/a6s-cloud/app/Console/Kernel.php
@@ -25,7 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->call(new BatchedAnalysisRequests)->everyMinute();
+        $schedule->call(new BatchedAnalysisRequests)->everyTenMinutes();
     }
 
     /**

--- a/a6s-cloud/app/Console/Kernel.php
+++ b/a6s-cloud/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use App\Schedules\BatchedAnalysisRequests;
 
 class Kernel extends ConsoleKernel
 {
@@ -24,9 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->call(function() {
-            logger(print_r('Hello Laravel Schedule!!', true));
-        })->everyMinute();
+        $schedule->call(new BatchedAnalysisRequests)->everyMinute();
     }
 
     /**

--- a/a6s-cloud/app/Console/Kernel.php
+++ b/a6s-cloud/app/Console/Kernel.php
@@ -24,8 +24,9 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        $schedule->call(function() {
+            logger(print_r('Hello Laravel Schedule!!', true));
+        })->everyMinute();
     }
 
     /**

--- a/a6s-cloud/app/Console/Kernel.php
+++ b/a6s-cloud/app/Console/Kernel.php
@@ -25,7 +25,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->call(new BatchedAnalysisRequests)->everyTenMinutes();
+        // $schedule->call(new BatchedAnalysisRequests)->everyTenMinutes();
+        $schedule->call(new BatchedAnalysisRequests)->everyMinute();
     }
 
     /**

--- a/a6s-cloud/app/Console/Kernel.php
+++ b/a6s-cloud/app/Console/Kernel.php
@@ -25,8 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->call(new BatchedAnalysisRequests)->everyTenMinutes();
-        $schedule->call(new BatchedAnalysisRequests)->everyMinute();
+        $schedule->call(new BatchedAnalysisRequests)->everyTenMinutes();
     }
 
     /**

--- a/a6s-cloud/app/Schedules/BatchedAnalysisRequests.php
+++ b/a6s-cloud/app/Schedules/BatchedAnalysisRequests.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Schedules;
+
+class BatchedAnalysisRequests
+{
+    public function __invoke()
+    {
+        logger(print_r('BatchedAnalysisRequests was called!!', true));
+    }
+}
+// $obj = new BatchedAnalysisRequests;
+// $obj(5);
+// var_dump(is_callable($obj));
+// ?>

--- a/a6s-cloud/app/Schedules/BatchedAnalysisRequests.php
+++ b/a6s-cloud/app/Schedules/BatchedAnalysisRequests.php
@@ -1,14 +1,41 @@
 <?php
 namespace App\Schedules;
 
+use AnalysisRequestService;
+use TwitterClientService;
+use App\AnalysisResults;
+
 class BatchedAnalysisRequests
 {
     public function __invoke()
     {
-        logger(print_r('BatchedAnalysisRequests was called!!', true));
+        logger(print_r('解析依頼バッチ開始', true));
+
+        $jobs = AnalysisResults::where('status', '=', '0')->get();
+        if (count($jobs) === 0) {
+            logger(print_r('バッチ処理すべき解析依頼がありません(0件)', true));
+            return;
+        };
+
+        foreach ($jobs as &$job) {
+            logger(print_r('解析依頼処理開始[job.id: ' . $job->id . ', analysis_word: '
+                    . $job->analysis_word . ', analysis_start_date: '
+                    . $job->analysis_start_date . ', analysis_end_date: ' . $job->analysis_end_date . ']', true));
+
+            $job->status = 0;       // TODO: 1
+            $job->save();
+
+            $localStorage = AnalysisRequestService::getLocalStorage();
+            $tweetsFileForWordcloud = AnalysisRequestService::getTweetsFileForWordcloud();
+
+            $params = array(
+                'start_date' => '2019-05-11',
+                'analysis_word' => '#Google'
+            );
+            $summary = TwitterClientService::createTweetText($job->id, $params, $localStorage, $tweetsFileForWordcloud);
+        }
+
+        logger(print_r('解析依頼バッチ開始', true));
     }
 }
-// $obj = new BatchedAnalysisRequests;
-// $obj(5);
-// var_dump(is_callable($obj));
-// ?>
+

--- a/a6s-cloud/app/Schedules/BatchedAnalysisRequests.php
+++ b/a6s-cloud/app/Schedules/BatchedAnalysisRequests.php
@@ -13,7 +13,8 @@ class BatchedAnalysisRequests
     {
         logger(print_r('解析依頼バッチ開始', true));
 
-        $jobs = AnalysisResults::where('status', '=', '0')->get();
+        $today = Carbon::today()->format('Y-m-d 00:00:00');
+        $jobs = AnalysisResults::where('status', '=', '0')->where('analysis_start_date', '<', $today)->get();
         if (count($jobs) === 0) {
             logger(print_r('バッチ処理すべき解析依頼がありません(0件)', true));
             return;
@@ -35,7 +36,7 @@ class BatchedAnalysisRequests
             $tweetsFileForWordcloud = AnalysisRequestService::getTweetsFileForWordcloud();
 
             // Tweet 取得用のパラメータを構築する
-            $start_date_for_twitter = (new Carbon($job->start_date))->format('Y-m-d');
+            $start_date_for_twitter = (new Carbon($job->analysis_start_date))->format('Y-m-d');
             $params_for_twitter = array(
                 'start_date' => $start_date_for_twitter,
                 'analysis_word' => $job->analysis_word

--- a/a6s-cloud/app/Services/AnalysisRequestService.php
+++ b/a6s-cloud/app/Services/AnalysisRequestService.php
@@ -31,6 +31,10 @@ class AnalysisRequestService
         $this->publicStoragePath = Storage::disk('public')->getDriver()->getAdapter()->getPathPrefix();
     }
 
+    public function setAResult($result) {
+        $this->aResult = $result;
+    }
+
     public function getRequestParameters(Request $request)
     {
         return array(
@@ -124,9 +128,9 @@ class AnalysisRequestService
     {
         $process = new Process([
             'python3',
-            '../../a6s-cloud-batch/src/createWordCloud.py',
+            base_path() . '/../a6s-cloud-batch/src/createWordCloud.py',
             $this->localStoragePath . $this->getTweetsFileForWordcloud(),
-            '../../RictyDiminished/RictyDiminished-Bold.ttf',
+            base_path() . '/../RictyDiminished/RictyDiminished-Bold.ttf',
             $this->publicStoragePath . $this->getImageFileForWordcloud()
         ]);
         $process->run();

--- a/build.sh
+++ b/build.sh
@@ -200,15 +200,6 @@ init_mysql_db() {
         php artisan db:seed
     '
 
-    # docker-compose exec mysql bash -c '
-    #     set -e
-    #     DB_PW_ROOT="root"
-    #     DB_NAME="a6s_cloud"
-
-    #     echo "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
-    #     MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
-    # '
-
     docker-compose exec workspace bash -c '
         # cd /var/www/a6s-cloud
         # [[ ! -L ./public/storage ]] && php artisan storage:link

--- a/build.sh
+++ b/build.sh
@@ -96,6 +96,7 @@ build() {
             echo "ERROR: /var/www/a6s-cloud ディレクトリがありません。Laravel プロジェクトの作成に失敗しました。" >&2
             exit 1
         fi
+        echo "* * * * * laradock /usr/bin/php /var/www/a6s-cloud/artisan schedule:run >> /dev/null 2>&1" > /etc/cron.d/laradock
     '
 
     docker-compose exec workspace runuser -l laradock -c '

--- a/build.sh
+++ b/build.sh
@@ -153,6 +153,8 @@ init_mysql_db() {
         echo ">>> sql: ALTER USER '"'"'default'"'"'@'"'"'%'"'"' IDENTIFIED WITH mysql_native_password BY '"'"'secret'"'"';"
         MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "ALTER USER '"'"'default'"'"'@'"'"'%'"'"' IDENTIFIED WITH mysql_native_password BY '"'"'secret'"'"';"
         # MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "SELECT user, host, plugin FROM mysql.user;" | grep -E "^default"
+        echo "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
+        MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
     '
     docker-compose exec php-fpm bash -c '
         set -e
@@ -192,22 +194,44 @@ init_mysql_db() {
         sync
         echo "NOTICE: プロジェクトのDB 接続先を設定しました"
         grep -E "(^DB_HOST|^DB_DATABASE|^DB_USERNAME)"              .env
-    '
 
-    docker-compose exec mysql bash -c '
-        set -e
-        DB_PW_ROOT="root"
-        DB_NAME="a6s_cloud"
-
-        echo "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
-        MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
-    '
-
-    docker-compose exec workspace runuser -l laradock -c '
-        cd /var/www/a6s-cloud
         [[ ! -L ./public/storage ]] && php artisan storage:link
         php artisan migrate:refresh
         php artisan db:seed
+    '
+
+    # docker-compose exec mysql bash -c '
+    #     set -e
+    #     DB_PW_ROOT="root"
+    #     DB_NAME="a6s_cloud"
+
+    #     echo "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
+    #     MYSQL_PWD="${DB_PW_ROOT}" mysql -u root <<< "GRANT ALL ON ${DB_NAME}.* TO '"'"'default'"'"'@'"'"'%'"'"';"
+    # '
+
+    docker-compose exec workspace bash -c '
+        # cd /var/www/a6s-cloud
+        # [[ ! -L ./public/storage ]] && php artisan storage:link
+        # php artisan migrate:refresh
+        # php artisan db:seed
+
+        # python3 環境の構築
+        pkg_cache=$(apt list --installed 2> /dev/null | grep -v -E "Listing..." | cut -d "/" -f 1)
+        declare -a target=("python3" "python3\-pip")
+        for (( i = 0; i < ${#target[@]}; ++i )) {
+            p="${target[i]}"
+
+            if ! (grep -E "^${p}$" &> /dev/null <<< "$pkg_cache"); then
+                echo "python3, python3-pip をインストールします"
+                apt-get update
+                DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends python3 python3-pip
+                break
+            fi
+        }
+
+        for pipackage in matplotlib janome wordcloud; do
+            pip3 --disable-pip-version-check install "$pipackage"
+        done
     '
 }
 


### PR DESCRIPTION
# 対応内容
#130 の内容を実装しました。

# 確認方法
* build.sh を実行して再度コンテナ環境を構築しなおしてください
```
./build.sh
```
* 昨日以前、本日以前、明日以降と解析依頼レコードを作成して、昨日以前のレコードのみ処理されることを確認してください。解析は10分単位で走ります

```
-- SQL 例
INSERT INTO analysis_results (analysis_start_date, analysis_end_date, analysis_word, status) VALUES ('2019-05-10 00:00:00', '2019-05-10 23:59:59', '#Google', 0);
INSERT INTO analysis_results (analysis_start_date, analysis_end_date, analysis_word, status) VALUES ('2019-05-11 00:00:00', '2019-05-11 23:59:59', '#Google', 0);
INSERT INTO analysis_results (analysis_start_date, analysis_end_date, analysis_word, status) VALUES ('2019-05-12 00:00:00', '2019-05-11 23:59:59', '#Google', 0);
```

* ログを見て処理されたことを確認してください(`/storage/logs/laravel-YYYY-MM-DD.log`)
* フロントも起動して解析結果一覧を表示すると、昨日以前のやつだけ処理されていることが確認できると思います

# クローズするissue
close #130

# このタスクで発生したissue
#152

# その他
量が多くなってしまいました。要リファクタリングです。。
筋肉不足でAPI制限を見る処理までは実装できませんでした…💪。
Laradock の構成の都合上、php コンテナとworkspace コンテナにpython 実行環境が必要であることがわかりました。なのでbuild.sh を再実行してから確認お願いします。

phpコンテナ: フロントから解析依頼を受け取って解析を実行する時はこちらのpython 環境を使う
workspace コンテナ: Laravel のスケジュール(cron) から解析を実行する時はこちらのpython 環境を使う